### PR TITLE
Add contextual information to Pitch objects

### DIFF
--- a/src/harpstrata/Pitch/getPitch/index.test.ts
+++ b/src/harpstrata/Pitch/getPitch/index.test.ts
@@ -1,12 +1,30 @@
-import { PitchIds } from '../types'
+import { PitchIds, NoteFoundations } from '../types'
 import type { Pitch } from '../types'
 
 import { getPitch } from './index'
 
 
-test('getPitch function can return a first pozition', () => {
-  const C_PITCH: Pitch = { id: PitchIds.C } as const
+test('getPitch function can return a C pitch', () => {
+  const C_PITCH: Pitch = {
+    id: PitchIds.C,
+    contextualDisplayValue: {
+      natural: NoteFoundations.C
+    }
+  } as const
   const actualPitch = getPitch(C_PITCH.id)
 
   expect(actualPitch).toStrictEqual(C_PITCH)
+})
+
+test('getPitch function can return a Db pitch', () => {
+  const DB_PITCH: Pitch = {
+    id: PitchIds.Db,
+    contextualDisplayValue: {
+      flat: NoteFoundations.D,
+      sharp: NoteFoundations.C
+    }
+  } as const
+  const actualPitch = getPitch(DB_PITCH.id)
+
+  expect(actualPitch).toStrictEqual(DB_PITCH)
 })

--- a/src/harpstrata/Pitch/getPitch/index.test.ts
+++ b/src/harpstrata/Pitch/getPitch/index.test.ts
@@ -7,7 +7,7 @@ import { getPitch } from './index'
 test('getPitch function can return a C pitch', () => {
   const C_PITCH: Pitch = {
     id: PitchIds.C,
-    contextualDisplayValue: {
+    contextualDisplayValues: {
       natural: NoteFoundations.C
     }
   } as const
@@ -19,7 +19,7 @@ test('getPitch function can return a C pitch', () => {
 test('getPitch function can return a Db pitch', () => {
   const DB_PITCH: Pitch = {
     id: PitchIds.Db,
-    contextualDisplayValue: {
+    contextualDisplayValues: {
       flat: NoteFoundations.D,
       sharp: NoteFoundations.C
     }

--- a/src/harpstrata/Pitch/getPitch/index.ts
+++ b/src/harpstrata/Pitch/getPitch/index.ts
@@ -1,7 +1,7 @@
 import { PitchIds, NoteFoundations } from '../types'
-import type { Pitch, NaturalDisplayValue, UnnaturalDisplayValue } from '../types'
+import type { Pitch, NaturalDisplayValue, UnnaturalDisplayValues } from '../types'
 
-const pitchMap: Record<PitchIds, NaturalDisplayValue | UnnaturalDisplayValue> = {
+const pitchMap: Record<PitchIds, NaturalDisplayValue | UnnaturalDisplayValues> = {
   [PitchIds.A]: {
     natural: NoteFoundations.A
   },

--- a/src/harpstrata/Pitch/getPitch/index.ts
+++ b/src/harpstrata/Pitch/getPitch/index.ts
@@ -1,4 +1,48 @@
-import { PitchIds } from '../types'
-import type { Pitch } from '../types'
+import { PitchIds, NoteFoundations } from '../types'
+import type { Pitch, ContextualDisplayValue } from '../types'
 
-export const getPitch = (pitchId: PitchIds): Pitch => ({ id: pitchId })
+const pitchMap: Record<PitchIds, ContextualDisplayValue> = {
+  [PitchIds.A]: {
+    natural: NoteFoundations.A
+  },
+  [PitchIds.Bb]: {
+    sharp: NoteFoundations.A,
+    flat: NoteFoundations.B,
+  },
+  [PitchIds.B]: {
+    natural: NoteFoundations.B
+  },
+  [PitchIds.C]: {
+    natural: NoteFoundations.C
+  },
+  [PitchIds.Db]: {
+    sharp: NoteFoundations.C,
+    flat: NoteFoundations.D,
+  },
+  [PitchIds.D]: {
+    natural: NoteFoundations.D
+  },
+  [PitchIds.Eb]: {
+    sharp: NoteFoundations.D,
+    flat: NoteFoundations.E,
+  },
+  [PitchIds.E]: {
+    natural: NoteFoundations.E
+  },
+  [PitchIds.F]: {
+    natural: NoteFoundations.F
+  },
+  [PitchIds.Gb]: {
+    sharp: NoteFoundations.F,
+    flat: NoteFoundations.G,
+  },
+  [PitchIds.G]: {
+    natural: NoteFoundations.G
+  },
+  [PitchIds.Ab]: {
+    sharp: NoteFoundations.G,
+    flat: NoteFoundations.A,
+  },
+}
+
+export const getPitch = (pitchId: PitchIds): Pitch => ({id: pitchId, contextualDisplayValue: pitchMap[pitchId]})

--- a/src/harpstrata/Pitch/getPitch/index.ts
+++ b/src/harpstrata/Pitch/getPitch/index.ts
@@ -1,7 +1,7 @@
 import { PitchIds, NoteFoundations } from '../types'
-import type { Pitch, ContextualDisplayValue } from '../types'
+import type { Pitch, ContextualDisplayValues } from '../types'
 
-const pitchMap: Record<PitchIds, ContextualDisplayValue> = {
+const pitchMap: Record<PitchIds, ContextualDisplayValues> = {
   [PitchIds.A]: {
     natural: NoteFoundations.A
   },

--- a/src/harpstrata/Pitch/getPitch/index.ts
+++ b/src/harpstrata/Pitch/getPitch/index.ts
@@ -1,7 +1,7 @@
 import { PitchIds, NoteFoundations } from '../types'
-import type { Pitch, ContextualDisplayValues } from '../types'
+import type { Pitch, NaturalDisplayValue, UnnaturalDisplayValue } from '../types'
 
-const pitchMap: Record<PitchIds, ContextualDisplayValues> = {
+const pitchMap: Record<PitchIds, NaturalDisplayValue | UnnaturalDisplayValue> = {
   [PitchIds.A]: {
     natural: NoteFoundations.A
   },
@@ -45,4 +45,11 @@ const pitchMap: Record<PitchIds, ContextualDisplayValues> = {
   },
 }
 
-export const getPitch = (pitchId: PitchIds): Pitch => ({id: pitchId, contextualDisplayValues: pitchMap[pitchId]})
+export const getPitch = (pitchId: PitchIds): Pitch => {
+  const pitch = {
+    id: pitchId,
+    contextualDisplayValues: pitchMap[pitchId]
+  } as Pitch
+
+  return pitch
+}

--- a/src/harpstrata/Pitch/getPitch/index.ts
+++ b/src/harpstrata/Pitch/getPitch/index.ts
@@ -45,4 +45,4 @@ const pitchMap: Record<PitchIds, ContextualDisplayValue> = {
   },
 }
 
-export const getPitch = (pitchId: PitchIds): Pitch => ({id: pitchId, contextualDisplayValue: pitchMap[pitchId]})
+export const getPitch = (pitchId: PitchIds): Pitch => ({id: pitchId, contextualDisplayValues: pitchMap[pitchId]})

--- a/src/harpstrata/Pitch/index.ts
+++ b/src/harpstrata/Pitch/index.ts
@@ -2,9 +2,9 @@ export { getPitch } from './getPitch'
 
 export { getPitchMatrix } from './getPitchMatrix'
 
-export type { Pitch, PitchRow, PitchMatrix } from './types'
+export type { Pitch, NaturalPitch, UnnaturalPitch, PitchRow, PitchMatrix } from './types'
 export { PitchIds } from './types'
 
-export { isPitchId } from './typeguards'
+export { isPitchId, isNaturalPitch } from './typeguards'
 
 export { EXAMPLE_PITCH_MATRICES } from './testResources'

--- a/src/harpstrata/Pitch/typeguards/index.test.ts
+++ b/src/harpstrata/Pitch/typeguards/index.test.ts
@@ -1,7 +1,8 @@
 import { PitchIds } from '../types'
+import { getPitch } from '../getPitch'
 import { PozitionIds } from '../../Pozition'
 
-import { isPitchId } from './index'
+import { isPitchId, isNaturalDisplayValues } from './index'
 
 test('isPitchId returns true for a PitchIds and false otherwise', () => {
   const { C: pitchId } = PitchIds
@@ -9,4 +10,12 @@ test('isPitchId returns true for a PitchIds and false otherwise', () => {
 
   expect(isPitchId(pitchId)).toBeTruthy()
   expect(isPitchId(pozitionId)).toBeFalsy()
+})
+
+test('isNaturalPitch returns true for a natural PitchIds and false otherwise', () => {
+  const c = getPitch(PitchIds.C)
+  const db = getPitch(PitchIds.Db)
+
+  expect(isNaturalDisplayValues(c.contextualDisplayValues)).toBeTruthy()
+  expect(isNaturalDisplayValues(db.contextualDisplayValues)).toBeFalsy()
 })

--- a/src/harpstrata/Pitch/typeguards/index.test.ts
+++ b/src/harpstrata/Pitch/typeguards/index.test.ts
@@ -2,7 +2,7 @@ import { PitchIds } from '../types'
 import { getPitch } from '../getPitch'
 import { PozitionIds } from '../../Pozition'
 
-import { isPitchId, isNaturalDisplayValues } from './index'
+import { isPitchId, isNaturalPitch } from './index'
 
 test('isPitchId returns true for a PitchIds and false otherwise', () => {
   const { C: pitchId } = PitchIds
@@ -12,10 +12,10 @@ test('isPitchId returns true for a PitchIds and false otherwise', () => {
   expect(isPitchId(pozitionId)).toBeFalsy()
 })
 
-test('isNaturalPitch returns true for a natural PitchIds and false otherwise', () => {
+test('isNaturalPitch returns true for a natural Pitch and false otherwise', () => {
   const c = getPitch(PitchIds.C)
   const db = getPitch(PitchIds.Db)
 
-  expect(isNaturalDisplayValues(c.contextualDisplayValues)).toBeTruthy()
-  expect(isNaturalDisplayValues(db.contextualDisplayValues)).toBeFalsy()
+  expect(isNaturalPitch(c)).toBeTruthy()
+  expect(isNaturalPitch(db)).toBeFalsy()
 })

--- a/src/harpstrata/Pitch/typeguards/index.ts
+++ b/src/harpstrata/Pitch/typeguards/index.ts
@@ -1,5 +1,11 @@
 import { PitchIds } from '../types'
+import type { ContextualDisplayValues, NaturalDisplayValue } from '../types'
 
 export const isPitchId = (idIn: string): idIn is PitchIds => {
   return Object.values(PitchIds).includes(idIn as PitchIds)
+}
+
+export const isNaturalDisplayValues = (displayValues: ContextualDisplayValues): displayValues is NaturalDisplayValue => {
+  const { natural } = displayValues as NaturalDisplayValue
+  return natural !== undefined
 }

--- a/src/harpstrata/Pitch/typeguards/index.ts
+++ b/src/harpstrata/Pitch/typeguards/index.ts
@@ -1,11 +1,11 @@
 import { PitchIds } from '../types'
-import type { ContextualDisplayValues, NaturalDisplayValue } from '../types'
+import type { NaturalPitch, Pitch } from '../types'
 
 export const isPitchId = (idIn: string): idIn is PitchIds => {
   return Object.values(PitchIds).includes(idIn as PitchIds)
 }
 
-export const isNaturalDisplayValues = (displayValues: ContextualDisplayValues): displayValues is NaturalDisplayValue => {
-  const { natural } = displayValues as NaturalDisplayValue
+export const isNaturalPitch = (pitch: Pitch): pitch is NaturalPitch => {
+  const { contextualDisplayValues: { natural } } = pitch as NaturalPitch
   return natural !== undefined
 }

--- a/src/harpstrata/Pitch/types/index.ts
+++ b/src/harpstrata/Pitch/types/index.ts
@@ -23,18 +23,18 @@ export enum NoteFoundations {
   G = 'G',
 }
 
-type NaturalDisplayValue = {
+export type NaturalDisplayValue = {
   readonly natural: NoteFoundations;
 }
-type UnnaturalDisplayValue = {
+export type UnnaturalDisplayValue = {
   readonly sharp: NoteFoundations;
   readonly flat: NoteFoundations;
 }
-export type ContextualDisplayValue = NaturalDisplayValue | UnnaturalDisplayValue
+export type ContextualDisplayValues = NaturalDisplayValue | UnnaturalDisplayValue
 
 export type Pitch = {
   readonly id: PitchIds;
-  readonly contextualDisplayValues: ContextualDisplayValue;
+  readonly contextualDisplayValues: ContextualDisplayValues;
 }
 
 export type PitchRow = ReadonlyArray<Pitch | undefined>

--- a/src/harpstrata/Pitch/types/index.ts
+++ b/src/harpstrata/Pitch/types/index.ts
@@ -34,7 +34,7 @@ export type ContextualDisplayValue = NaturalDisplayValue | UnnaturalDisplayValue
 
 export type Pitch = {
   readonly id: PitchIds;
-  readonly contextualDisplayValue: ContextualDisplayValue;
+  readonly contextualDisplayValues: ContextualDisplayValue;
 }
 
 export type PitchRow = ReadonlyArray<Pitch | undefined>

--- a/src/harpstrata/Pitch/types/index.ts
+++ b/src/harpstrata/Pitch/types/index.ts
@@ -13,8 +13,29 @@ export enum PitchIds {
   Ab = 'Ab',
 }
 
+export enum NoteFoundations {
+  A = 'A',
+  B = 'B',
+  C = 'C',
+  D = 'D',
+  E = 'E',
+  F = 'F',
+  G = 'G',
+}
+
+type NaturalDisplayValue = {
+  natural: NoteFoundations
+}
+type UnnaturalDisplayValue = {
+  sharp: NoteFoundations
+  flat: NoteFoundations
+}
+export type ContextualDisplayValue = NaturalDisplayValue | UnnaturalDisplayValue
+
+
 export type Pitch = {
   readonly id: PitchIds;
+  readonly contextualDisplayValue: ContextualDisplayValue
 }
 
 export type PitchRow = ReadonlyArray<Pitch | undefined>

--- a/src/harpstrata/Pitch/types/index.ts
+++ b/src/harpstrata/Pitch/types/index.ts
@@ -32,9 +32,8 @@ type UnnaturalDisplayValue = {
 }
 export type ContextualDisplayValue = NaturalDisplayValue | UnnaturalDisplayValue
 
-
 export type Pitch = {
-  readonly id: PitchIds;
+  readonly id: PitchIds
   readonly contextualDisplayValue: ContextualDisplayValue
 }
 

--- a/src/harpstrata/Pitch/types/index.ts
+++ b/src/harpstrata/Pitch/types/index.ts
@@ -26,7 +26,7 @@ export enum NoteFoundations {
 export type NaturalDisplayValue = {
   readonly natural: NoteFoundations;
 }
-export type UnnaturalDisplayValue = {
+export type UnnaturalDisplayValues = {
   readonly sharp: NoteFoundations;
   readonly flat: NoteFoundations;
 }
@@ -37,7 +37,7 @@ export type NaturalPitch = {
 }
 export type UnnaturalPitch = {
   readonly id: PitchIds;
-  readonly contextualDisplayValues: UnnaturalDisplayValue;
+  readonly contextualDisplayValues: UnnaturalDisplayValues;
 }
 export type Pitch = NaturalPitch | UnnaturalPitch
 

--- a/src/harpstrata/Pitch/types/index.ts
+++ b/src/harpstrata/Pitch/types/index.ts
@@ -30,12 +30,17 @@ export type UnnaturalDisplayValue = {
   readonly sharp: NoteFoundations;
   readonly flat: NoteFoundations;
 }
-export type ContextualDisplayValues = NaturalDisplayValue | UnnaturalDisplayValue
 
-export type Pitch = {
+export type NaturalPitch = {
   readonly id: PitchIds;
-  readonly contextualDisplayValues: ContextualDisplayValues;
+  readonly contextualDisplayValues: NaturalDisplayValue;
 }
+export type UnnaturalPitch = {
+  readonly id: PitchIds;
+  readonly contextualDisplayValues: UnnaturalDisplayValue;
+}
+export type Pitch = NaturalPitch | UnnaturalPitch
+
 
 export type PitchRow = ReadonlyArray<Pitch | undefined>
 export type PitchMatrix = ReadonlyArray<PitchRow>

--- a/src/harpstrata/Pitch/types/index.ts
+++ b/src/harpstrata/Pitch/types/index.ts
@@ -24,17 +24,17 @@ export enum NoteFoundations {
 }
 
 type NaturalDisplayValue = {
-  natural: NoteFoundations
+  readonly natural: NoteFoundations;
 }
 type UnnaturalDisplayValue = {
-  sharp: NoteFoundations
-  flat: NoteFoundations
+  readonly sharp: NoteFoundations;
+  readonly flat: NoteFoundations;
 }
 export type ContextualDisplayValue = NaturalDisplayValue | UnnaturalDisplayValue
 
 export type Pitch = {
-  readonly id: PitchIds
-  readonly contextualDisplayValue: ContextualDisplayValue
+  readonly id: PitchIds;
+  readonly contextualDisplayValue: ContextualDisplayValue;
 }
 
 export type PitchRow = ReadonlyArray<Pitch | undefined>

--- a/src/harpstrata/index.ts
+++ b/src/harpstrata/index.ts
@@ -16,8 +16,8 @@ export type { Pozition } from './Pozition'
 export { isPozitionId } from './Pozition'
 
 export { PitchIds } from './Pitch'
-export type { Pitch } from './Pitch'
-export { isPitchId } from './Pitch'
+export type { Pitch, NaturalPitch, UnnaturalPitch } from './Pitch'
+export { isPitchId, isNaturalPitch } from './Pitch'
 
 export { getCovariantSet } from './Covariant'
 export type {


### PR DESCRIPTION
There is a lot of depth to the question of how a given pitch is
represented. Sometimes you may even want to represent a C as a B#. That
kind of depth is not captured by this implementation. This
implementation basically just observes that black notes have a modifier
on them and which modifier that is depends on which foundation note you
are modifying from.

That seems to be sufficient for a representing notes on a harmonica
face. If the requirements become more intense then this can change.